### PR TITLE
feat: add mapterhorn.com as default tile provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,13 +82,15 @@ elevation = (red * 256 + green + blue / 256) - 32768
 **Tile URL Pattern:**
 
 ```
-https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png
+https://tiles.mapterhorn.com/{z}/{x}/{y}.webp
 ```
 
 **Default Configuration:**
 
 - Zoom Level: 12 (approximately 30m resolution)
 - Cache Size: 100 tiles maximum
+- Tile Size: 512 pixels
+- Attribution: mapterhorn.com (see https://mapterhorn.com/attribution/)
 
 ### Logging Strategy
 
@@ -142,10 +144,10 @@ The library implements a zero-overhead logging system for development debugging 
 ## Important Constraints
 
 1. **Minimal Dependencies**: Browser builds have zero runtime dependencies. Node.js builds require optional dependencies (`canvas`, `node-fetch`, `abort-controller`) that are dynamically imported.
-2. **Attribution Required**: Any usage must include attribution to data sources (SRTM, GMTED, NED, ETOPO1) and Mapzen/Tilezen processing
+2. **Attribution Required**: Any usage must include attribution per the tile provider. Default is mapterhorn.com — see https://mapterhorn.com/attribution/. Attribution is configurable via `ElevationProviderConfig.attribution`
 3. **Cross-Platform**: Library supports both browser (native APIs) and Node.js (with canvas package) environments
 4. **Coordinate Limits**: Latitude must be between -85.0511 and 85.0511 (Web Mercator bounds)
-5. **Memory Usage**: Each tile uses ~262KB (256×256×4 bytes) in both environments
+5. **Memory Usage**: Each tile uses ~1MB (512×512×4 bytes) with the default tile size in both environments
 
 ## Testing Strategy
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ const elevationProvider = new ElevationProvider({
     zoomLevel: 12, // Tile zoom level (default: 12 for ~30m resolution)
     cacheSize: 100, // Maximum tiles in memory cache (default: 100)
     tileUrlTemplate: 'https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png',
+    tileSize: 256,
 });
 
 // Batch elevation requests
@@ -460,36 +461,38 @@ Common errors:
 
 ## Attribution Requirements
 
-**IMPORTANT**: This library uses elevation data that requires proper attribution. You must include the following attribution in your application:
-
-### Required Attribution Text
-
-```
-Elevation data from multiple sources including SRTM, GMTED, NED and ETOPO1.
-Data processing by Mapzen/Tilezen.
-See https://github.com/tilezen/joerd for details.
-```
+**IMPORTANT**: Attribution is required by the tile data provider. The default configuration uses [mapterhorn.com](https://mapterhorn.com/) tiles — see [mapterhorn.com/attribution/](https://mapterhorn.com/attribution/) for their requirements.
 
 ### Implementation
 
 ```typescript
+const provider = new ElevationProvider();
+
 // Get attribution programmatically
-const attribution = ElevationProvider.getAttribution();
+const attribution = provider.getAttribution();
 
 // Display in your application's footer, about page, or credits
 document.getElementById('attribution').textContent = attribution.text;
-
-// Or include in your application's legal notices
-console.log('Data attribution:', attribution.text);
 console.log('More info:', attribution.url);
 ```
 
-### Legal Requirements
+### Custom Attribution
 
-- Attribution must be visible to end users
-- Include in documentation, about pages, or credits
-- Required for all applications using this library
-- See [Joerd attribution requirements](https://github.com/tilezen/joerd/blob/master/docs/attribution.md) for complete details
+When using a custom tile source, pass its attribution in the config:
+
+```typescript
+const provider = new ElevationProvider({
+    tileUrlTemplate: 'https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png',
+    tileSize: 256,
+    attribution: {
+        text: 'Elevation data from SRTM, GMTED, NED and ETOPO1. Data processing by Mapzen/Tilezen.',
+        url: 'https://github.com/tilezen/joerd',
+    },
+});
+```
+
+- See [Joerd attribution requirements](https://github.com/tilezen/joerd/blob/master/docs/attribution.md) when using Tilezen/AWS tiles
+- See [Mapterhorn attribution requirements](https://mapterhorn.com/attribution/) when using mapterhorn.com tiles
 
 ## Development
 
@@ -650,4 +653,4 @@ See [CHANGELOG.md](CHANGELOG.md) for version history and updates.
 
 ---
 
-**Data Attribution**: Elevation data from multiple sources including SRTM, GMTED, NED and ETOPO1. Data processing by Mapzen/Tilezen. See https://github.com/tilezen/joerd for details.
+**Data Attribution**: Default tile data provided by [Mapterhorn](https://mapterhorn.com/) — see [mapterhorn.com/attribution/](https://mapterhorn.com/attribution/) for requirements.

--- a/src/ElevationProvider.ts
+++ b/src/ElevationProvider.ts
@@ -31,14 +31,18 @@ export class ElevationProvider {
             zoomLevel: config.zoomLevel ?? 12,
             cacheSize: config.cacheSize ?? 100,
             tileUrlTemplate:
-                config.tileUrlTemplate ??
-                'https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png',
+                config.tileUrlTemplate ?? 'https://tiles.mapterhorn.com/{z}/{x}/{y}.webp',
+            tileSize: config.tileSize ?? 512,
+            attribution: config.attribution ?? {
+                text: 'Mapterhorn elevation data. See mapterhorn.com/attribution/ for details.',
+                url: 'https://mapterhorn.com/attribution/',
+            },
         };
         logger.dir('Config :', this.config);
 
         this.validateConfig();
         this.tileManager = new TileManager(this.config.tileUrlTemplate, this.config.cacheSize);
-        this.calculator = new ElevationCalculator(this.tileManager);
+        this.calculator = new ElevationCalculator(this.tileManager, this.config.tileSize);
         this.batchCalculator = new BatchCalculator(this.calculator);
     }
 
@@ -52,11 +56,8 @@ export class ElevationProvider {
     /**
      * Get attribution information for elevation data
      */
-    public static getAttribution(): Attribution {
-        return {
-            text: 'Elevation data from multiple sources including SRTM, GMTED, NED and ETOPO1. Data processing by Mapzen/Tilezen.',
-            url: 'https://github.com/tilezen/joerd',
-        };
+    public getAttribution(): Attribution {
+        return this.config.attribution;
     }
 
     // ============================================================================
@@ -139,6 +140,11 @@ export class ElevationProvider {
 
         if (!Number.isInteger(cacheSize) || cacheSize <= 0) {
             throw new Error(`Invalid cache size: ${cacheSize}. Must be a positive integer`);
+        }
+
+        const { tileSize } = this.config;
+        if (!Number.isInteger(tileSize) || tileSize <= 0 || (tileSize & (tileSize - 1)) !== 0) {
+            throw new Error(`Invalid tile size: ${tileSize}. Must be a positive power of 2`);
         }
     }
 }

--- a/src/calculator/ElevationCalculator.ts
+++ b/src/calculator/ElevationCalculator.ts
@@ -4,9 +4,11 @@ import type { TileManager } from '../tile';
 
 export class ElevationCalculator {
     private readonly tileManager: TileManager;
+    private readonly tileSize: number;
 
-    constructor(tileManager: TileManager) {
+    constructor(tileManager: TileManager, tileSize: number = 256) {
         this.tileManager = tileManager;
+        this.tileSize = tileSize;
     }
 
     // ========================================================================
@@ -22,7 +24,7 @@ export class ElevationCalculator {
             if (interpolation) {
                 return await this.getInterpolatedElevationInternal(coords, zoomLevel);
             } else {
-                const pixel = toPixel(coords, zoomLevel);
+                const pixel = toPixel(coords, zoomLevel, this.tileSize);
                 return await this.getElevationFromPixel(pixel);
             }
         } catch (error) {
@@ -41,7 +43,7 @@ export class ElevationCalculator {
         coords: Coordinates,
         zoomLevel: number
     ): Promise<number> {
-        const pixel = toPixel(coords, zoomLevel);
+        const pixel = toPixel(coords, zoomLevel, this.tileSize);
         const pixelFloat = {
             tile: pixel.tile,
             x: pixel.x,
@@ -56,16 +58,16 @@ export class ElevationCalculator {
         const dy = pixelFloat.y - y0;
 
         const p00 = await this.getElevationFromPixel(
-            normalizePixel({ tile: pixelFloat.tile, x: x0, y: y0 })
+            normalizePixel({ tile: pixelFloat.tile, x: x0, y: y0 }, this.tileSize)
         );
         const p10 = await this.getElevationFromPixel(
-            normalizePixel({ tile: pixelFloat.tile, x: x1, y: y0 })
+            normalizePixel({ tile: pixelFloat.tile, x: x1, y: y0 }, this.tileSize)
         );
         const p01 = await this.getElevationFromPixel(
-            normalizePixel({ tile: pixelFloat.tile, x: x0, y: y1 })
+            normalizePixel({ tile: pixelFloat.tile, x: x0, y: y1 }, this.tileSize)
         );
         const p11 = await this.getElevationFromPixel(
-            normalizePixel({ tile: pixelFloat.tile, x: x1, y: y1 })
+            normalizePixel({ tile: pixelFloat.tile, x: x1, y: y1 }, this.tileSize)
         );
 
         const top = p00 * (1 - dx) + p10 * dx;

--- a/src/calculator/ElevationFunctions.ts
+++ b/src/calculator/ElevationFunctions.ts
@@ -1,7 +1,5 @@
 import { Coordinates, Pixel, TileCoordinates, TileCoordinatesFloat } from 'src/types';
 
-const TILE_SIZE = 256;
-
 // ========================================================================
 // INTERNAL FUNCTIONS (exported for tests)
 // ========================================================================
@@ -34,7 +32,7 @@ export function isValidZoomLevel(zoom: number): boolean {
     return Number.isInteger(zoom) && zoom >= 0 && zoom <= 15;
 }
 
-export function normalizePixel(pixel: Pixel): Pixel {
+export function normalizePixel(pixel: Pixel, tileSize: number): Pixel {
     let { x, y } = pixel;
     const tile = pixel.tile;
     let tileX = tile.x;
@@ -42,19 +40,19 @@ export function normalizePixel(pixel: Pixel): Pixel {
     const z = tile.z;
 
     if (x < 0) {
-        x += TILE_SIZE;
+        x += tileSize;
         tileX -= 1;
     }
-    if (x >= TILE_SIZE) {
-        x -= TILE_SIZE;
+    if (x >= tileSize) {
+        x -= tileSize;
         tileX += 1;
     }
     if (y < 0) {
-        y += TILE_SIZE;
+        y += tileSize;
         tileY -= 1;
     }
-    if (y >= TILE_SIZE) {
-        y -= TILE_SIZE;
+    if (y >= tileSize) {
+        y -= tileSize;
         tileY += 1;
     }
 
@@ -119,12 +117,12 @@ export function toTileCoordinates(coords: Coordinates, z: number): TileCoordinat
  * @param z - Zoom level (0-15)
  * @returns Pixel coordinates within the appropriate tile
  */
-export function toPixel(coords: Coordinates, z: number): Pixel {
+export function toPixel(coords: Coordinates, z: number, tileSize: number): Pixel {
     const tile = toTileCoordinatesFloat(coords, z);
 
     // Calculate pixel coordinates within the tile
-    const x = Math.floor((tile.xFloat - tile.x) * TILE_SIZE);
-    const y = Math.floor((tile.yFloat - tile.y) * TILE_SIZE);
+    const x = Math.floor((tile.xFloat - tile.x) * tileSize);
+    const y = Math.floor((tile.yFloat - tile.y) * tileSize);
 
     return {
         tile: {
@@ -132,7 +130,7 @@ export function toPixel(coords: Coordinates, z: number): Pixel {
             x: tile.x,
             y: tile.y,
         },
-        x: Math.max(0, Math.min(TILE_SIZE - 1, x)),
-        y: Math.max(0, Math.min(TILE_SIZE - 1, y)),
+        x: Math.max(0, Math.min(tileSize - 1, x)),
+        y: Math.max(0, Math.min(tileSize - 1, y)),
     };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,17 @@ export interface ElevationProviderConfig {
      * Default: AWS S3 Terrarium tiles
      */
     readonly tileUrlTemplate?: string;
+
+    /**
+     * Tile size in pixels (default: 256)
+     * Use 512 for providers like mapterhorn.com
+     */
+    readonly tileSize?: number;
+
+    /**
+     * Attribution for the tile data source
+     */
+    readonly attribution?: Attribution;
 }
 
 /**

--- a/test/ElevationProvider.test.ts
+++ b/test/ElevationProvider.test.ts
@@ -33,7 +33,7 @@ describe('ElevationProvider', () => {
             async (coords, zoomLevel, _interpolation = true) => {
                 // Let the toPixel method run for validation - it will throw if invalid
                 // Use the exported toPixel function from ElevationFunctions
-                toPixel(coords, zoomLevel);
+                toPixel(coords, zoomLevel, 256);
 
                 return 0; // Default return value
             }
@@ -50,9 +50,8 @@ describe('ElevationProvider', () => {
 
             expect(config.zoomLevel).toBe(12);
             expect(config.cacheSize).toBe(100);
-            expect(config.tileUrlTemplate).toBe(
-                'https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png'
-            );
+            expect(config.tileUrlTemplate).toBe('https://tiles.mapterhorn.com/{z}/{x}/{y}.webp');
+            expect(config.tileSize).toBe(512);
         });
 
         it('should create provider with custom config', () => {
@@ -107,6 +106,29 @@ describe('ElevationProvider', () => {
 
             expect(() => new ElevationProvider({ cacheSize: 1.5 })).toThrow(
                 'Invalid cache size: 1.5. Must be a positive integer'
+            );
+        });
+
+        it('should create provider with custom tileSize', () => {
+            const provider = new ElevationProvider({ tileSize: 512 });
+            expect(provider.getConfig().tileSize).toBe(512);
+        });
+
+        it('should throw error for invalid tile size', () => {
+            expect(() => new ElevationProvider({ tileSize: 0 })).toThrow(
+                'Invalid tile size: 0. Must be a positive power of 2'
+            );
+
+            expect(() => new ElevationProvider({ tileSize: -256 })).toThrow(
+                'Invalid tile size: -256. Must be a positive power of 2'
+            );
+
+            expect(() => new ElevationProvider({ tileSize: 300 })).toThrow(
+                'Invalid tile size: 300. Must be a positive power of 2'
+            );
+
+            expect(() => new ElevationProvider({ tileSize: 1.5 })).toThrow(
+                'Invalid tile size: 1.5. Must be a positive power of 2'
             );
         });
 
@@ -331,8 +353,9 @@ describe('ElevationProvider', () => {
     });
 
     describe('attribution', () => {
-        it('should return attribution information', () => {
-            const attribution = ElevationProvider.getAttribution();
+        it('should return default attribution information', () => {
+            const provider = new ElevationProvider();
+            const attribution = provider.getAttribution();
 
             expect(attribution).toHaveProperty('text');
             expect(attribution).toHaveProperty('url');
@@ -342,9 +365,20 @@ describe('ElevationProvider', () => {
             expect(attribution.url).toContain('http');
         });
 
+        it('should return custom attribution when configured', () => {
+            const provider = new ElevationProvider({
+                attribution: { text: 'Custom attribution', url: 'https://example.com/attribution' },
+            });
+
+            const attribution = provider.getAttribution();
+            expect(attribution.text).toBe('Custom attribution');
+            expect(attribution.url).toBe('https://example.com/attribution');
+        });
+
         it('should return consistent attribution', () => {
-            const attr1 = ElevationProvider.getAttribution();
-            const attr2 = ElevationProvider.getAttribution();
+            const provider = new ElevationProvider();
+            const attr1 = provider.getAttribution();
+            const attr2 = provider.getAttribution();
 
             expect(attr1).toEqual(attr2);
         });

--- a/test/calculator/ElevationCalculator.test.ts
+++ b/test/calculator/ElevationCalculator.test.ts
@@ -187,7 +187,7 @@ describe('ElevationCalculator', () => {
             const elevation = await calculator.getElevation(coords, zoomLevel, false);
 
             // Verify the non-interpolated path was taken (lines 25-27)
-            expect(toPixelSpy).toHaveBeenCalledWith(coords, zoomLevel);
+            expect(toPixelSpy).toHaveBeenCalledWith(coords, zoomLevel, 256);
             expect(getElevationFromPixelSpy).toHaveBeenCalledWith({
                 tile: { z: 12, x: 2048, y: 2048 },
                 x: 128,

--- a/test/calculator/ElevationFunctions.test.ts
+++ b/test/calculator/ElevationFunctions.test.ts
@@ -10,7 +10,7 @@ describe('ElevationFunctions', () => {
                 y: 64,
             };
 
-            const result = normalizePixel(pixel);
+            const result = normalizePixel(pixel, 256);
 
             expect(result).toEqual({
                 tile: { z: 12, x: 100, y: 200 },
@@ -26,7 +26,7 @@ describe('ElevationFunctions', () => {
                 y: 128,
             };
 
-            const result = normalizePixel(pixel);
+            const result = normalizePixel(pixel, 256);
 
             expect(result.x).toBe(255);
             expect(result.tile.x).toBe(99);
@@ -41,7 +41,7 @@ describe('ElevationFunctions', () => {
                 y: -1,
             };
 
-            const result = normalizePixel(pixel);
+            const result = normalizePixel(pixel, 256);
 
             expect(result.x).toBe(128);
             expect(result.tile.x).toBe(100);
@@ -56,7 +56,7 @@ describe('ElevationFunctions', () => {
                 y: 128,
             };
 
-            const result = normalizePixel(pixel);
+            const result = normalizePixel(pixel, 256);
 
             expect(result.x).toBe(0);
             expect(result.tile.x).toBe(101);
@@ -71,7 +71,7 @@ describe('ElevationFunctions', () => {
                 y: 256,
             };
 
-            const result = normalizePixel(pixel);
+            const result = normalizePixel(pixel, 256);
 
             expect(result.x).toBe(128);
             expect(result.tile.x).toBe(100);
@@ -86,7 +86,7 @@ describe('ElevationFunctions', () => {
                 y: -10,
             };
 
-            const result = normalizePixel(pixel);
+            const result = normalizePixel(pixel, 256);
 
             expect(result.tile.x).toBe(0); // Clamped to minimum
             expect(result.tile.y).toBe(0); // Clamped to minimum
@@ -100,7 +100,7 @@ describe('ElevationFunctions', () => {
                 y: 300, // Will cause tile y to exceed bounds
             };
 
-            const result = normalizePixel(pixel);
+            const result = normalizePixel(pixel, 256);
 
             expect(result.tile.x).toBe(3); // Clamped to maximum (2^2 - 1 = 3)
             expect(result.tile.y).toBe(3); // Clamped to maximum
@@ -114,7 +114,7 @@ describe('ElevationFunctions', () => {
                 y: 300,
             };
 
-            const result = normalizePixel(pixel);
+            const result = normalizePixel(pixel, 256);
 
             // x: -10 → 246, tileX: 8-1 = 7
             expect(result.x).toBe(246);
@@ -133,7 +133,7 @@ describe('ElevationFunctions', () => {
                 y: -1,
             };
 
-            const result0 = normalizePixel(pixel0);
+            const result0 = normalizePixel(pixel0, 256);
             expect(result0.tile.x).toBe(0); // Clamped to valid range
             expect(result0.tile.y).toBe(0); // Clamped to valid range
 
@@ -144,7 +144,7 @@ describe('ElevationFunctions', () => {
                 y: 256,
             };
 
-            const result15 = normalizePixel(pixel15);
+            const result15 = normalizePixel(pixel15, 256);
             expect(result15.tile.x).toBe(32767); // Should remain at max
             expect(result15.tile.y).toBe(32767); // Should remain at max
         });


### PR DESCRIPTION
## Summary

- Switch default tile source to mapterhorn.com (512×512 WebP tiles)
- Add `tileSize` to `ElevationProviderConfig` — configurable, validated as a positive power of 2
- Add `attribution` to `ElevationProviderConfig` — replaces the old static `getAttribution()` with a configurable instance method
- Remove hardcoded `TILE_SIZE=256`; tile size now flows through `ElevationCalculator` into `toPixel()` and `normalizePixel()`
- Update README and CLAUDE.md to reflect new defaults

## Test Plan

- [x] `npm test` — 290 tests passing
- [x] `npm run typecheck` — no errors
- [x] `npm run lint` — no warnings
- [x] Verify mapterhorn tiles load correctly in browser demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)