### PR TITLE
chore: configure Dependabot dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,44 +1,43 @@
-# Dependabot configuration for automatic dependency updates
 version: 2
 updates:
-  # Enable version updates for npm
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "04:00"
+      time: "09:30"
+      timezone: "Europe/Paris"
     open-pull-requests-limit: 10
-    pull-request-branch-name:
-      separator: "/"
+    assignees:
+      - "glandais"
     commit-message:
-      prefix: "chore"
-      prefix-development: "chore"
+      prefix: "deps(npm)"
       include: "scope"
     labels:
       - "dependencies"
-      - "npm"
-    assignees:
-      - "glandais"
     groups:
-      # Group all minor and patch updates together
       minor-and-patch:
         update-types:
           - "minor"
           - "patch"
 
-  # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "04:00"
+      time: "10:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 5
+    assignees:
+      - "glandais"
     commit-message:
-      prefix: "ci"
+      prefix: "deps(github-actions)"
       include: "scope"
     labels:
       - "dependencies"
-      - "github-actions"
-    assignees:
-      - "glandais"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Standardizes the Dependabot configuration to match the tribly reference standard:

- **npm** (`/`): weekly on Monday at 09:30 Europe/Paris, limit 10 PRs, grouped minor+patch, commit prefix `deps(npm)`
- **github-actions** (`/`): weekly on Monday at 10:00 Europe/Paris, limit 5 PRs, grouped minor+patch, commit prefix `deps(github-actions)`

Changes from the previous config:
- Updated schedule times to match the standard (09:30 for npm, 10:00 for github-actions)
- Added `timezone: "Europe/Paris"` to all schedules
- Updated commit-message prefixes to `deps(<ecosystem>)` format
- Removed extra labels (`npm`, `github-actions`) — only `dependencies` label is used
- Removed non-standard `pull-request-branch-name` key
- Added missing `open-pull-requests-limit` and `groups` for github-actions block

🤖 Generated with [Claude Code](https://claude.com/claude-code)