### PR TITLE
fix: decode WebP tiles in Node.js with sharp

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,11 @@ const ElevationProvider = require('@glandais/elevation').default;
 For Node.js environments, install with optional dependencies:
 
 ```bash
-npm install @glandais/elevation canvas node-fetch abort-controller
+npm install @glandais/elevation canvas sharp node-fetch abort-controller
 ```
+
+`sharp` decodes the terrain tiles. It is required for the default WebP tile source:
+`canvas` links no libwebp and cannot decode WebP at all.
 
 ```javascript
 // ES6 import
@@ -402,7 +405,8 @@ The library uses terrain data processed from multiple sources:
 ### Node.js Support
 
 - Node.js 18+ with optional dependencies:
-    - `canvas`: For image processing
+    - `sharp`: For tile decoding (WebP and PNG)
+    - `canvas`: For image data handling
     - `node-fetch`: For HTTP requests (Node.js < 18)
     - `abort-controller`: For request cancellation (Node.js < 15)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
             "dependencies": {
                 "abort-controller": "^3.0.0",
                 "canvas": "^3.2.0",
-                "node-fetch": "^3.3.2"
+                "node-fetch": "^3.3.2",
+                "sharp": "^0.35.3"
             },
             "devDependencies": {
                 "@commitlint/cli": "^21.0.0",
@@ -671,13 +672,11 @@
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-            "dev": true,
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+            "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -710,6 +709,506 @@
                 "@noble/hashes": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@img/colour": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+            "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@img/sharp-darwin-arm64": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+            "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-darwin-arm64": "1.3.2"
+            }
+        },
+        "node_modules/@img/sharp-darwin-x64": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+            "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-darwin-x64": "1.3.2"
+            }
+        },
+        "node_modules/@img/sharp-freebsd-wasm32": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+            "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "dependencies": {
+                "@img/sharp-wasm32": "0.35.3"
+            },
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-darwin-arm64": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+            "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-darwin-x64": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+            "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-arm": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+            "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-arm64": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+            "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-ppc64": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+            "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-riscv64": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+            "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-s390x": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+            "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-x64": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+            "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+            "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+            "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-linux-arm": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+            "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-arm": "1.3.2"
+            }
+        },
+        "node_modules/@img/sharp-linux-arm64": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+            "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-arm64": "1.3.2"
+            }
+        },
+        "node_modules/@img/sharp-linux-ppc64": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+            "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-ppc64": "1.3.2"
+            }
+        },
+        "node_modules/@img/sharp-linux-riscv64": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+            "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-riscv64": "1.3.2"
+            }
+        },
+        "node_modules/@img/sharp-linux-s390x": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+            "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+            "cpu": [
+                "s390x"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-s390x": "1.3.2"
+            }
+        },
+        "node_modules/@img/sharp-linux-x64": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+            "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-x64": "1.3.2"
+            }
+        },
+        "node_modules/@img/sharp-linuxmusl-arm64": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+            "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+            }
+        },
+        "node_modules/@img/sharp-linuxmusl-x64": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+            "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+            }
+        },
+        "node_modules/@img/sharp-wasm32": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+            "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+            "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/runtime": "^1.11.1"
+            },
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-webcontainers-wasm32": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+            "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+            "cpu": [
+                "wasm32"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@img/sharp-wasm32": "0.35.3"
+            },
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-win32-arm64": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+            "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-win32-ia32": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+            "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-win32-x64": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+            "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@jridgewell/resolve-uri": {
@@ -9843,6 +10342,55 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
+        "node_modules/sharp": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+            "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@img/colour": "^1.1.0",
+                "detect-libc": "^2.1.2",
+                "semver": "^7.8.5"
+            },
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-darwin-arm64": "0.35.3",
+                "@img/sharp-darwin-x64": "0.35.3",
+                "@img/sharp-freebsd-wasm32": "0.35.3",
+                "@img/sharp-libvips-darwin-arm64": "1.3.2",
+                "@img/sharp-libvips-darwin-x64": "1.3.2",
+                "@img/sharp-libvips-linux-arm": "1.3.2",
+                "@img/sharp-libvips-linux-arm64": "1.3.2",
+                "@img/sharp-libvips-linux-ppc64": "1.3.2",
+                "@img/sharp-libvips-linux-riscv64": "1.3.2",
+                "@img/sharp-libvips-linux-s390x": "1.3.2",
+                "@img/sharp-libvips-linux-x64": "1.3.2",
+                "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+                "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+                "@img/sharp-linux-arm": "0.35.3",
+                "@img/sharp-linux-arm64": "0.35.3",
+                "@img/sharp-linux-ppc64": "0.35.3",
+                "@img/sharp-linux-riscv64": "0.35.3",
+                "@img/sharp-linux-s390x": "0.35.3",
+                "@img/sharp-linux-x64": "0.35.3",
+                "@img/sharp-linuxmusl-arm64": "0.35.3",
+                "@img/sharp-linuxmusl-x64": "0.35.3",
+                "@img/sharp-webcontainers-wasm32": "0.35.3",
+                "@img/sharp-win32-arm64": "0.35.3",
+                "@img/sharp-win32-ia32": "0.35.3",
+                "@img/sharp-win32-x64": "0.35.3"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/shebang-command": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -10566,7 +11114,6 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "dev": true,
             "license": "0BSD",
             "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "dependencies": {
         "abort-controller": "^3.0.0",
         "canvas": "^3.2.0",
+        "sharp": "^0.35.3",
         "node-fetch": "^3.3.2"
     }
 }

--- a/src/tile/fetcher/nodejs/NodeJsTileFetcher.ts
+++ b/src/tile/fetcher/nodejs/NodeJsTileFetcher.ts
@@ -1,43 +1,59 @@
-import { Canvas, createCanvas, loadImage } from 'canvas';
-import { CanvasPool, TileFetcher } from '..';
+import { ImageData } from 'canvas';
+import sharp from 'sharp';
+import { TileFetcher } from '..';
 import { Tile } from '../..';
 import { NodeTile } from './NodeJsTile';
 
+// ============================================================================
+// NODE.JS TILE FETCHER - HTTP client + WebP/PNG decoder
+// ============================================================================
+
+/**
+ * Node.js implementation of TileFetcher.
+ *
+ * Terrain tiles are decoded with sharp (libvips + libwebp), which handles WebP
+ * (lossy and lossless/VP8L) as well as PNG. The `canvas` package is not used for
+ * decoding: it links no libwebp and rejects every WebP with
+ * `Unsupported image type`.
+ *
+ * IMPORTANT - Terrarium tiles are data, not pictures. Elevation is packed into
+ * the raw RGB bit patterns (`red * 256 + green + blue / 256 - 32768`), so the
+ * decode must stay byte-exact:
+ * - no alpha premultiplication (it would rewrite R, G and B),
+ * - no colour management / ICC / colourspace conversion,
+ * - no resize or resample.
+ * `sharp(...).raw()` guarantees this by default; nothing here may add
+ * `.premultiply()`, `.toColourspace()` or `.resize()`. Getting it wrong throws
+ * nothing - a one-LSB change in the red channel is silently 256 metres.
+ */
 export class NodeJsTileFetcher implements TileFetcher {
-    private readonly canvasPool: CanvasPool<Canvas>;
-
-    constructor() {
-        this.canvasPool = new CanvasPool<Canvas>(() => createCanvas(256, 256));
-    }
-
     /**
-     * Fetch a tile image and return both ImageData and ImageBitmap for memory management
+     * Fetch a tile image and decode it to raw RGBA pixels
      * @param url - The URL of the tile to fetch
-     * @param tileKey - The tile identifier for logging
-     * @returns Promise<Tile> - Object containing ImageData and ImageBitmap
+     * @returns Promise<Tile> - Tile giving access to the decoded pixels
      */
     public async fetchTile(url: string): Promise<Tile> {
-        const image = await loadImage(url);
-        // Acquire canvas from pool
-        const canvas = this.canvasPool.acquire();
+        const response = await fetch(url);
 
-        try {
-            // Resize canvas to match image dimensions
-            if (canvas.width !== image.width) {
-                canvas.width = image.width;
-            }
-            if (canvas.height !== image.height) {
-                canvas.height = image.height;
-            }
-
-            const ctx = canvas.getContext('2d');
-
-            ctx.drawImage(image, 0, 0);
-            const data = ctx.getImageData(0, 0, image.width, image.height);
-            return new NodeTile(data);
-        } finally {
-            // Always return canvas to pool for reuse
-            this.canvasPool.release(canvas);
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}: ${response.statusText}`);
         }
+
+        const encoded = Buffer.from(await response.arrayBuffer());
+
+        // ensureAlpha(): NodeTile indexes a 4-channel buffer, so a 3-channel
+        // decode of an opaque tile would shift every pixel.
+        const { data, info } = await sharp(encoded)
+            .ensureAlpha()
+            .raw()
+            .toBuffer({ resolveWithObject: true });
+
+        if (info.premultiplied || info.channels !== 4) {
+            throw new Error(
+                `Unexpected decode for ${url}: channels=${info.channels}, premultiplied=${info.premultiplied}`
+            );
+        }
+
+        return new NodeTile(new ImageData(new Uint8ClampedArray(data), info.width, info.height));
     }
 }

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -72,10 +72,14 @@ global.ImageData = class ImageData {
 } as unknown as typeof ImageData;
 
 // Mock canvas for TileFetcher tests
-Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
-    value: vi.fn().mockReturnValue({
-        drawImage: vi.fn(),
-        getImageData: vi.fn().mockReturnValue(new ImageData(256, 256)),
-    }),
-    writable: true,
-});
+// Guarded: tests running with `@vitest-environment node` (e.g. NodeJsTileFetcher)
+// have no DOM, and need no canvas mock.
+if (typeof HTMLCanvasElement !== 'undefined') {
+    Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+        value: vi.fn().mockReturnValue({
+            drawImage: vi.fn(),
+            getImageData: vi.fn().mockReturnValue(new ImageData(256, 256)),
+        }),
+        writable: true,
+    });
+}

--- a/test/tile/fetcher/nodejs/NodeJsTileFetcher.test.ts
+++ b/test/tile/fetcher/nodejs/NodeJsTileFetcher.test.ts
@@ -1,0 +1,207 @@
+// @vitest-environment node
+//
+// This is the only test that runs the real Node.js code path: the whole rest of
+// the suite runs under jsdom with `__NODE__ = false` and therefore always goes
+// through BrowserTileFetcher. Here the real fetcher and the real sharp decoder
+// are exercised, with only the network stubbed.
+
+import sharp from 'sharp';
+import type { Pixel } from '../../../../src/types';
+import { NodeJsTileFetcher } from '../../../../src/tile/fetcher/nodejs/NodeJsTileFetcher';
+
+// 4x2 RGBA fixture. Values are chosen to be meaningful as Terrarium data:
+// - neighbouring pixels differ by a single LSB in the red channel (256 m apart),
+//   so any colour transform shows up immediately
+// - two pixels are semi-transparent, so any alpha premultiplication rewrites
+//   their RGB
+const FIXTURE_WIDTH = 4;
+const FIXTURE_HEIGHT = 2;
+const FIXTURE_RGBA = new Uint8Array([
+    // row 0
+    130, 13, 133, 255, 131, 13, 133, 255, 129, 191, 237, 128, 0, 0, 0, 255,
+    // row 1
+    128, 0, 0, 128, 255, 255, 255, 255, 129, 143, 253, 255, 1, 2, 3, 255,
+]);
+
+async function encodeLosslessWebp(
+    rgba: Uint8Array,
+    width: number,
+    height: number,
+    channels: 3 | 4
+) {
+    return await sharp(Buffer.from(rgba), { raw: { width, height, channels } })
+        .webp({ lossless: true })
+        .toBuffer();
+}
+
+// Tile.getElevation only uses x/y; the tile coordinates are irrelevant here
+function pixel(x: number, y: number): Pixel {
+    return { tile: { z: 12, x: 0, y: 0 }, x, y };
+}
+
+function stubFetch(
+    body: Buffer | undefined,
+    init?: { ok?: boolean; status?: number; statusText?: string }
+) {
+    const response = {
+        ok: init?.ok ?? true,
+        status: init?.status ?? 200,
+        statusText: init?.statusText ?? 'OK',
+        arrayBuffer: async () =>
+            body
+                ? body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength)
+                : new ArrayBuffer(0),
+    };
+    const fetchMock = vi.fn().mockResolvedValue(response);
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+}
+
+describe('NodeJsTileFetcher', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it('decodes a lossless WebP tile to raw, unpremultiplied RGBA', async () => {
+        const webp = await encodeLosslessWebp(FIXTURE_RGBA, FIXTURE_WIDTH, FIXTURE_HEIGHT, 4);
+        // Sanity check: the fixture really is a lossless WebP (RIFF/WEBP/VP8L)
+        expect(webp.subarray(0, 4).toString('ascii')).toBe('RIFF');
+        expect(webp.subarray(8, 15).toString('ascii')).toBe('WEBPVP8');
+
+        const fetchMock = stubFetch(webp);
+
+        const tile = await new NodeJsTileFetcher().fetchTile('https://example.test/12/1/2.webp');
+
+        expect(fetchMock).toHaveBeenCalledWith('https://example.test/12/1/2.webp');
+        expect(tile.width).toBe(FIXTURE_WIDTH);
+        expect(tile.height).toBe(FIXTURE_HEIGHT);
+
+        // Byte-for-byte: no premultiply, no colour management, no resample
+        for (let i = 0; i < FIXTURE_RGBA.length; i += 4) {
+            expect(tile.getRGBFromImageData(i)).toEqual({
+                red: FIXTURE_RGBA[i],
+                green: FIXTURE_RGBA[i + 1],
+                blue: FIXTURE_RGBA[i + 2],
+            });
+        }
+
+        // Terrarium decoding of the first two pixels: one LSB of red is 256 m
+        expect(tile.getElevation(pixel(0, 0))).toBeCloseTo(525.52, 2);
+        expect(tile.getElevation(pixel(1, 0))).toBeCloseTo(781.52, 2);
+
+        // Semi-transparent pixel keeps its RGB (premultiplication would give 64/95/118)
+        expect(tile.getRGBFromImageData(2 * 4)).toEqual({ red: 129, green: 191, blue: 237 });
+
+        tile.close();
+    });
+
+    it('adds an alpha channel when the tile has no alpha', async () => {
+        const rgb = new Uint8Array(FIXTURE_WIDTH * FIXTURE_HEIGHT * 3);
+        for (let p = 0; p < FIXTURE_WIDTH * FIXTURE_HEIGHT; p++) {
+            rgb[p * 3] = FIXTURE_RGBA[p * 4];
+            rgb[p * 3 + 1] = FIXTURE_RGBA[p * 4 + 1];
+            rgb[p * 3 + 2] = FIXTURE_RGBA[p * 4 + 2];
+        }
+        const webp = await encodeLosslessWebp(rgb, FIXTURE_WIDTH, FIXTURE_HEIGHT, 3);
+        stubFetch(webp);
+
+        const tile = await new NodeJsTileFetcher().fetchTile('https://example.test/rgb.webp');
+
+        // A 3-channel decode would shift every pixel; assert the 4-channel layout
+        for (let p = 0; p < FIXTURE_WIDTH * FIXTURE_HEIGHT; p++) {
+            expect(tile.getRGBFromImageData(p * 4)).toEqual({
+                red: rgb[p * 3],
+                green: rgb[p * 3 + 1],
+                blue: rgb[p * 3 + 2],
+            });
+        }
+    });
+
+    it('decodes PNG tiles as well', async () => {
+        const png = await sharp(Buffer.from(FIXTURE_RGBA), {
+            raw: { width: FIXTURE_WIDTH, height: FIXTURE_HEIGHT, channels: 4 },
+        })
+            .png()
+            .toBuffer();
+        stubFetch(png);
+
+        const tile = await new NodeJsTileFetcher().fetchTile('https://example.test/tile.png');
+
+        expect(tile.getRGBFromImageData(0)).toEqual({ red: 130, green: 13, blue: 133 });
+    });
+
+    it('throws on a non-ok HTTP response', async () => {
+        stubFetch(undefined, { ok: false, status: 404, statusText: 'Not Found' });
+
+        await expect(
+            new NodeJsTileFetcher().fetchTile('https://example.test/missing.webp')
+        ).rejects.toThrow('HTTP 404: Not Found');
+    });
+
+    it('rejects when the payload is not a decodable image', async () => {
+        stubFetch(Buffer.from('not an image'));
+
+        await expect(
+            new NodeJsTileFetcher().fetchTile('https://example.test/garbage.webp')
+        ).rejects.toThrow();
+    });
+
+    it('rejects a premultiplied or non-RGBA decode instead of returning wrong metres', async () => {
+        vi.resetModules();
+        vi.doMock('sharp', () => {
+            const chain = {
+                ensureAlpha: () => chain,
+                raw: () => chain,
+                toBuffer: async () => ({
+                    data: Buffer.alloc(FIXTURE_WIDTH * FIXTURE_HEIGHT * 4),
+                    info: {
+                        width: FIXTURE_WIDTH,
+                        height: FIXTURE_HEIGHT,
+                        channels: 4,
+                        premultiplied: true,
+                    },
+                }),
+            };
+            return { default: () => chain };
+        });
+
+        stubFetch(Buffer.from('ignored'));
+        const { NodeJsTileFetcher: MockedFetcher } =
+            await import('../../../../src/tile/fetcher/nodejs/NodeJsTileFetcher');
+
+        await expect(new MockedFetcher().fetchTile('https://example.test/pm.webp')).rejects.toThrow(
+            /premultiplied=true/
+        );
+
+        vi.doUnmock('sharp');
+        vi.resetModules();
+    });
+});
+
+// Live network check against the default tile source. Opt-in:
+//   INTEGRATION=1 npx vitest run test/tile/fetcher/nodejs/NodeJsTileFetcher.test.ts
+describe.skipIf(!process.env.INTEGRATION)('NodeJsTileFetcher (live tiles)', () => {
+    it('decodes a mapterhorn WebP tile with the default URL template', async () => {
+        const tile = await new NodeJsTileFetcher().fetchTile(
+            'https://tiles.mapterhorn.com/12/2109/1465.webp'
+        );
+
+        expect(tile.width).toBe(512);
+        expect(tile.height).toBe(512);
+
+        const expected: Array<[number, number, [number, number, number], number]> = [
+            [0, 0, [130, 13, 133], 525.52],
+            [1, 0, [130, 13, 32], 525.13],
+            [255, 255, [129, 191, 237], 447.93],
+            [300, 120, [129, 190, 198], 446.77],
+            [511, 511, [129, 143, 253], 399.99],
+        ];
+
+        for (const [x, y, [red, green, blue], elevation] of expected) {
+            const index = (y * tile.width + x) * 4;
+            expect(tile.getRGBFromImageData(index)).toEqual({ red, green, blue });
+            expect(tile.getElevation(pixel(x, y))).toBeCloseTo(elevation, 2);
+        }
+    }, 30000);
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,7 +37,7 @@ export default defineConfig(({ mode }) => {
                     },
                 },
                 rolldownOptions: {
-                    external: ['canvas', 'node-fetch', 'abort-controller'],
+                    external: ['canvas', 'sharp', 'node-fetch', 'abort-controller'],
                     output: {
                         exports: 'named',
                         codeSplitting: false,
@@ -72,12 +72,13 @@ export default defineConfig(({ mode }) => {
                     },
                 },
                 rolldownOptions: {
-                    external: ['canvas', 'node-fetch', 'abort-controller'],
+                    external: ['canvas', 'sharp', 'node-fetch', 'abort-controller'],
                     output: {
                         exports: 'named',
                         codeSplitting: false,
                         globals: {
                             canvas: 'canvas',
+                            sharp: 'sharp',
                             'node-fetch': 'fetch',
                             'abort-controller': 'AbortController',
                         },


### PR DESCRIPTION
## Problem

`NodeJsTileFetcher` decoded tiles with `loadImage()` from `canvas`. The installed `canvas` (3.2.3) links **no libwebp** — `ldd` resolves 30 shared objects and none is `libwebp`, and the module exports no `WEBPStream`/`webpVersion`. Every WebP failed with `Unsupported image type`, whatever the encoding.

Since the default tile source is WebP-only (`https://tiles.mapterhorn.com/{z}/{x}/{y}.webp`; the `.png` variant 404s), `new ElevationProvider()` returned no elevation at all in Node.js, and there was no configuration workaround.

The whole test suite runs under jsdom with `__NODE__ = false`, so every test went through `BrowserTileFetcher` and the broken path was never exercised.

## Fix

Decode with `sharp` (libvips 8.18.3 / libwebp 1.6.0) instead:

- fetch the tile bytes, decode straight to raw RGBA — the `createCanvas` / `drawImage` / `getImageData` round-trip existed only to get pixels out of an `Image`
- keep the decode byte-exact. Terrarium packs elevation into the RGB bit patterns (`red * 256 + green + blue / 256 - 32768`), so no premultiply, no colour management, no resample. `sharp(...).raw()` guarantees this; a guard rejects the tile if the decoder ever reports `premultiplied` or `channels !== 4`, because a one-LSB shift in red is a silent 256 m
- `ensureAlpha()` so a 3-channel tile cannot shift `NodeTile`'s 4-channel indexing

`NodeTile`, `Tile`, `CanvasPool` and the browser path are unchanged. `canvas` is kept only for `ImageData`. `sharp` is external in both builds and verified absent from `dist/index.esm.js`, `index.umd.js` and `index.min.js`.

## Tests

New `test/tile/fetcher/nodejs/NodeJsTileFetcher.test.ts` — the first test of the fetcher itself, running with `@vitest-environment node` and the real decoder, network stubbed:

- pins RGBA byte-for-byte through a lossless-WebP round trip, including semi-transparent pixels that premultiplication would rewrite
- 3-channel input gets an alpha channel; PNG still decodes; non-ok HTTP and undecodable bytes reject; the premultiply guard fires
- opt-in live check (`INTEGRATION=1`) reproducing the five reference pixels of `12/2109/1465.webp` exactly

`test/setup.ts` guards its canvas mock on `typeof HTMLCanvasElement !== 'undefined'` so node-environment files can share the setup.

## Verification

- `lint`, `typecheck`, 296 unit tests, 8 Playwright browser tests, `build` — all pass; coverage 96.8% statements / 96.4% branches
- live tiles through the built `dist/index.node.mjs` with no caller configuration: Mont Blanc 4757.99 m, Dead Sea −432 m, Everest 8718 m, `getElevationsAlong` densifies as expected
- decoded RGBA matches Pillow and `sharp` reference hashes for `12/2109/1465.webp`

## Notes for review

- `sharp` went into `dependencies` next to `canvas`, matching the existing convention. Worth deciding whether both should become optional/peer instead.
- Two pre-existing numeric bugs surfaced while cross-checking against the Kotlin port, both **outside** this change and left untouched since they alter public output for every caller:
  1. `toPixel` (`src/calculator/ElevationFunctions.ts`) floors the in-tile coordinates, so `getInterpolatedElevationInternal` always has `dx = dy = 0` — bilinear interpolation is a no-op library-wide.
  2. `Tile.decodeElevation` rounds to 2 decimals, losing the exact 1/256 steps.

  Feeding the true corner values through fractional bilinear gives 4756.570320 against the Kotlin reference 4756.571557; the residual 1.2e-3 is exactly that rounding — which also confirms the decode is byte-exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)